### PR TITLE
feat(session): accept/reject後に自動で次のhunkへジャンプ

### DIFF
--- a/lua/copilot_hunk/session.lua
+++ b/lua/copilot_hunk/session.lua
@@ -102,6 +102,13 @@ function M.accept_at_cursor(bufnr)
 
   hunk_mod.accept(hunk)
   ui.render(bufnr, session.hunks, session.opts)
+
+  -- Auto-jump to next pending hunk (VSCode Copilot behaviour).
+  local next = hunk_mod.next_hunk(line, session.hunks)
+  if next then
+    vim.api.nvim_win_set_cursor(0, { next.start_after, 0 })
+  end
+
   M._check_complete(bufnr, session)
 end
 
@@ -120,6 +127,13 @@ function M.reject_at_cursor(bufnr)
 
   hunk_mod.reject(hunk, bufnr, session.hunks)
   ui.render(bufnr, session.hunks, session.opts)
+
+  -- Auto-jump to next pending hunk (VSCode Copilot behaviour).
+  local next = hunk_mod.next_hunk(line, session.hunks)
+  if next then
+    vim.api.nvim_win_set_cursor(0, { next.start_after, 0 })
+  end
+
   M._check_complete(bufnr, session)
 end
 


### PR DESCRIPTION
## 概要

issue #1 の実装。GitHub Copilot (VSCode) と同じ操作感で、hunkをacceptまたはrejectした直後に自動的に次のpending hunkへカーソルが移動するようにした。

## 変更内容

### `lua/copilot_hunk/session.lua`

`accept_at_cursor()` と `reject_at_cursor()` に自動ジャンプロジックを追加。

```lua
-- render後、次のpending hunkへ自動ジャンプ
local next = hunk_mod.next_hunk(line, session.hunks)
if next then
  vim.api.nvim_win_set_cursor(0, { next.start_after, 0 })
end
```

## 動作

- `ga` / `gr` で操作後、次のpending hunkが存在する場合は自動ジャンプ
- 最後のhunkを操作した場合はジャンプなし（セッション終了メッセージが出る）
- `gA` / `gR` は変更なし（一括操作なのでジャンプ不要）

## 影響範囲

- `session.lua` のみ変更
- 既存のUI・diff・hunkロジックへの影響なし

closes #1