### PR TITLE
feat: グローバルhunkカウンター + ロボットアイコン装飾 (closes #18 #19)

### DIFF
--- a/lua/copilot_hunk/decoration.lua
+++ b/lua/copilot_hunk/decoration.lua
@@ -1,0 +1,111 @@
+--- decoration.lua
+--- Handles UI decorations for active sessions.
+--- Provides: diagnostic API, buffer variable, User event, optional WinBar.
+
+local M = {}
+
+local _ns = nil  -- diagnostic namespace
+
+--- Initialize decoration subsystem. Called from setup().
+function M.setup()
+  _ns = vim.api.nvim_create_namespace("copilot_hunk_diag")
+end
+
+--- Mark a buffer as having AI-pending hunks.
+--- @param bufnr number
+--- @param pending_count number
+--- @param opts table  plugin opts
+function M.mark(bufnr, pending_count, opts)
+  if not vim.api.nvim_buf_is_valid(bufnr) then return end
+  opts = opts or {}
+  local icon = (opts.decorations and opts.decorations.icon) or "🤖"
+
+  vim.b[bufnr].copilot_hunk_active = true
+  vim.b[bufnr].copilot_hunk_count  = pending_count
+
+  if _ns then
+    vim.diagnostic.set(_ns, bufnr, {
+      {
+        lnum     = 0,
+        col      = 0,
+        severity = vim.diagnostic.severity.HINT,
+        message  = string.format("AI変更あり (%d hunk)", pending_count),
+        source   = "copilot-hunk",
+      },
+    }, { virtual_text = false, signs = false, underline = false })
+  end
+
+  local show_winbar = opts.decorations and opts.decorations.winbar
+  if show_winbar then
+    local label = string.format(" %s AI変更あり [%d]", icon, pending_count)
+    for _, win in ipairs(vim.fn.win_findbuf(bufnr)) do
+      local cur = vim.wo[win].winbar or ""
+      if cur == "" or cur:find("copilot%-hunk", 1, true) then
+        vim.wo[win].winbar = "%#CopilotHunkCount#" .. label .. "%*"
+      end
+    end
+  end
+
+  vim.api.nvim_exec_autocmds("User", {
+    pattern  = "CopilotHunkSessionChanged",
+    data     = { bufnr = bufnr, active = true, pending = pending_count },
+    modeline = false,
+  })
+end
+
+--- Remove decorations when session ends or all hunks resolved.
+--- @param bufnr number
+--- @param opts? table
+function M.unmark(bufnr, opts)
+  if not vim.api.nvim_buf_is_valid(bufnr) then return end
+  opts = opts or {}
+
+  vim.b[bufnr].copilot_hunk_active = false
+  vim.b[bufnr].copilot_hunk_count  = 0
+
+  if _ns then
+    vim.diagnostic.reset(_ns, bufnr)
+  end
+
+  local show_winbar = opts.decorations and opts.decorations.winbar
+  if show_winbar then
+    for _, win in ipairs(vim.fn.win_findbuf(bufnr)) do
+      local cur = vim.wo[win].winbar or ""
+      if cur:find("copilot%-hunk", 1, true) then
+        vim.wo[win].winbar = ""
+      end
+    end
+  end
+
+  vim.api.nvim_exec_autocmds("User", {
+    pattern  = "CopilotHunkSessionChanged",
+    data     = { bufnr = bufnr, active = false, pending = 0 },
+    modeline = false,
+  })
+end
+
+--- Update decoration after accept/reject.
+--- @param bufnr number
+--- @param pending_count number
+--- @param opts table
+function M.update(bufnr, pending_count, opts)
+  if pending_count > 0 then
+    M.mark(bufnr, pending_count, opts)
+  else
+    M.unmark(bufnr, opts)
+  end
+end
+
+--- Statusline/tabline helper.
+--- Returns "🤖 N" when current buffer has pending AI hunks, else "".
+function M.statusline_component()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local active = vim.b[bufnr].copilot_hunk_active
+  local count  = vim.b[bufnr].copilot_hunk_count or 0
+  if active and count > 0 then
+    return string.format("🤖 %d", count)
+  end
+  return ""
+end
+
+return M

--- a/lua/copilot_hunk/session.lua
+++ b/lua/copilot_hunk/session.lua
@@ -2,10 +2,41 @@
 --- Manages per-buffer review sessions.
 --- Each session stores base_lines, the computed hunks, and plugin options.
 
-local diff_mod = require("copilot_hunk.diff")
-local hunk_mod = require("copilot_hunk.hunk")
-local ui       = require("copilot_hunk.ui")
-local keymap   = require("copilot_hunk.keymap")
+local diff_mod   = require("copilot_hunk.diff")
+local hunk_mod   = require("copilot_hunk.hunk")
+local ui         = require("copilot_hunk.ui")
+local keymap     = require("copilot_hunk.keymap")
+local decoration = require("copilot_hunk.decoration")
+
+--- @private
+--- Calculate the global hunk offset and total across all active sessions.
+--- Counts non-rejected hunks (pending + accepted) to keep counter stable
+--- until a hunk is explicitly rejected.
+--- @param bufnr number
+--- @return number offset  non-rejected hunks in sessions before bufnr in _session_order
+--- @return number total   total non-rejected hunks across ALL active sessions
+local function global_counts(bufnr)
+  local M_ref = require("copilot_hunk.session")
+  local offset = 0
+  local total  = 0
+  local found  = false
+  for _, b in ipairs(M_ref._session_order) do
+    local s = M_ref._sessions[b]
+    if not s then goto continue end
+    local cnt = 0
+    for _, h in ipairs(s.hunks) do
+      if h.status ~= "rejected" then cnt = cnt + 1 end
+    end
+    if b == bufnr then
+      found = true
+    elseif not found then
+      offset = offset + cnt
+    end
+    total = total + cnt
+    ::continue::
+  end
+  return offset, total
+end
 
 local M = {}
 
@@ -52,8 +83,11 @@ function M.start(bufnr, base_lines, opts)
   }
 
   table.insert(M._session_order, bufnr)
+  decoration.mark(bufnr, #hunks, opts)
 
-  ui.render(bufnr, hunks, opts)
+  local off, tot = global_counts(bufnr)
+  ui.render(bufnr, hunks, opts, off, tot)
+  M._rerender_all()
   keymap.attach(bufnr)
 
   -- Auto-close session when the buffer is deleted.
@@ -83,6 +117,8 @@ function M.stop(bufnr, opts)
   end
 
   ui.clear(bufnr)
+  local sess_opts = session and session.opts or {}
+  decoration.unmark(bufnr, sess_opts)
   keymap.detach(bufnr)
   M._sessions[bufnr] = nil
 
@@ -115,9 +151,17 @@ function M.accept_at_cursor(bufnr)
   end
 
   hunk_mod.accept(hunk)
-  ui.render(bufnr, session.hunks, session.opts)
+  local off, tot = global_counts(bufnr)
+  ui.render(bufnr, session.hunks, session.opts, off, tot)
 
   M._check_complete(bufnr, session)
+  M._rerender_all()
+  local upd_s = M.get(bufnr)
+  if upd_s then
+    local pend = 0
+    for _, h in ipairs(upd_s.hunks) do if h.status == "pending" then pend = pend + 1 end end
+    decoration.update(bufnr, pend, upd_s.opts)
+  end
   if M.get(bufnr) then
     M.goto_next(bufnr)
   end
@@ -137,9 +181,17 @@ function M.reject_at_cursor(bufnr)
   end
 
   hunk_mod.reject(hunk, bufnr, session.hunks)
-  ui.render(bufnr, session.hunks, session.opts)
+  local off, tot = global_counts(bufnr)
+  ui.render(bufnr, session.hunks, session.opts, off, tot)
 
   M._check_complete(bufnr, session)
+  M._rerender_all()
+  local upd_s2 = M.get(bufnr)
+  if upd_s2 then
+    local pend = 0
+    for _, h in ipairs(upd_s2.hunks) do if h.status == "pending" then pend = pend + 1 end end
+    decoration.update(bufnr, pend, upd_s2.opts)
+  end
   if M.get(bufnr) then
     M.goto_next(bufnr)
   end
@@ -157,8 +209,16 @@ function M.accept_all(bufnr)
     end
   end
 
-  ui.render(bufnr, session.hunks, session.opts)
+  local off1, tot1 = global_counts(bufnr)
+  ui.render(bufnr, session.hunks, session.opts, off1, tot1)
   M._check_complete(bufnr, session)
+  M._rerender_all()
+  local upd_s3 = M.get(bufnr)
+  if upd_s3 then
+    local pend = 0
+    for _, h in ipairs(upd_s3.hunks) do if h.status == "pending" then pend = pend + 1 end end
+    decoration.update(bufnr, pend, upd_s3.opts)
+  end
 end
 
 --- Reject all pending hunks.
@@ -174,8 +234,16 @@ function M.reject_all(bufnr)
     end
   end
 
-  ui.render(bufnr, session.hunks, session.opts)
+  local off2, tot2 = global_counts(bufnr)
+  ui.render(bufnr, session.hunks, session.opts, off2, tot2)
   M._check_complete(bufnr, session)
+  M._rerender_all()
+  local upd_s4 = M.get(bufnr)
+  if upd_s4 then
+    local pend = 0
+    for _, h in ipairs(upd_s4.hunks) do if h.status == "pending" then pend = pend + 1 end end
+    decoration.update(bufnr, pend, upd_s4.opts)
+  end
 end
 
 --- Jump to the next pending hunk, crossing file boundaries with wrap-around.
@@ -259,6 +327,19 @@ function M._check_complete(bufnr, session)
 
   M.stop(bufnr)
   vim.notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO)
+end
+
+--- @private
+--- Re-render all active sessions with globally-correct hunk counters.
+--- Call this after any accept/reject to keep counters in sync across files.
+function M._rerender_all()
+  for _, b in ipairs(M._session_order) do
+    local s = M._sessions[b]
+    if s then
+      local off, tot = global_counts(b)
+      ui.render(b, s.hunks, s.opts, off, tot)
+    end
+  end
 end
 
 --- @private

--- a/lua/copilot_hunk/ui.lua
+++ b/lua/copilot_hunk/ui.lua
@@ -68,7 +68,9 @@ end
 --- @param bufnr number
 --- @param hunks Hunk[]
 --- @param opts table  plugin options
-function M.render(bufnr, hunks, opts)
+--- @param global_offset? number  non-rejected hunk count in sessions before this one
+--- @param global_total?  number  total non-rejected hunks across all active sessions
+function M.render(bufnr, hunks, opts, global_offset, global_total)
   M.clear(bufnr)
   local ns = M.ns()
   local show_signs = opts and opts.signs ~= false
@@ -79,7 +81,7 @@ function M.render(bufnr, hunks, opts)
     end
   end
 
-  M._render_hunk_counters(bufnr, ns, hunks)
+  M._render_hunk_counters(bufnr, ns, hunks, global_offset, global_total)
 end
 
 --- @private
@@ -210,25 +212,37 @@ function M._render_char_diff(bufnr, ns, hunk)
 end
 
 --- Render [n/N] hunk counter as EOL virtual text on each hunk's first line.
+--- Uses global_offset/global_total when provided (cross-file counter).
+--- Falls back to local-only counting if globals are not supplied.
+--- @param global_offset? number
+--- @param global_total?  number
 --- @private
-function M._render_hunk_counters(bufnr, ns, hunks)
+function M._render_hunk_counters(bufnr, ns, hunks, global_offset, global_total)
   local line_count = vim.api.nvim_buf_line_count(bufnr)
-  local pending = {}
+
+  -- Count non-rejected hunks for fallback local total.
+  local fallback_total = 0
+  for _, h in ipairs(hunks) do
+    if h.status ~= "rejected" then fallback_total = fallback_total + 1 end
+  end
+
+  local total  = global_total  or fallback_total
+  local offset = global_offset or 0
+  local local_idx = 0
+
   for _, h in ipairs(hunks) do
     if h.status ~= "rejected" then
-      pending[#pending + 1] = h
-    end
-  end
-  local total = #pending
-  for idx, h in ipairs(pending) do
-    if h.status == "pending" then
-      local row = math.max(h.start_after - 1, 0)  -- 0-indexed
-      if row < line_count then
-        vim.api.nvim_buf_set_extmark(bufnr, ns, row, 0, {
-          virt_text = { { string.format("[%d/%d]", idx, total), "CopilotHunkCount" } },
-          virt_text_pos = "eol",
-          priority = 90,
-        })
+      local_idx = local_idx + 1
+      if h.status == "pending" then
+        local global_idx = offset + local_idx
+        local row = math.max(h.start_after - 1, 0)  -- 0-indexed
+        if row < line_count then
+          vim.api.nvim_buf_set_extmark(bufnr, ns, row, 0, {
+            virt_text = { { string.format("[%d/%d]", global_idx, total), "CopilotHunkCount" } },
+            virt_text_pos = "eol",
+            priority = 90,
+          })
+        end
       end
     end
   end

--- a/spec/global_counter_spec.lua
+++ b/spec/global_counter_spec.lua
@@ -1,0 +1,140 @@
+--- spec/global_counter_spec.lua
+--- Tests for the global hunk counter ([n/N] across all files).
+
+local function make_buf(lines)
+  local bufnr = vim.api.nvim_create_buf(true, false)
+  vim.bo[bufnr].buftype = ""
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  return bufnr
+end
+
+describe("global hunk counter", function()
+  local session
+  local opts = { keymaps = false, signs = false, highlights = {} }
+
+  before_each(function()
+    package.loaded["copilot_hunk.session"]    = nil
+    package.loaded["copilot_hunk.ui"]         = nil
+    package.loaded["copilot_hunk.diff"]       = nil
+    package.loaded["copilot_hunk.hunk"]       = nil
+    package.loaded["copilot_hunk.keymap"]     = nil
+    package.loaded["copilot_hunk.decoration"] = nil
+    session = require("copilot_hunk.session")
+  end)
+
+  after_each(function()
+    local order = vim.deepcopy(session._session_order)
+    for _, bufnr in ipairs(order) do
+      session.stop(bufnr, { silent = true })
+    end
+  end)
+
+  it("single buffer: offset=0, total=local hunk count", function()
+    local bufnr = make_buf({ "a", "b", "c" })
+    -- base has 3 lines, buf has different content → 1 change hunk
+    session.start(bufnr, { "x", "b", "c" }, opts)
+    local s = session.get(bufnr)
+    assert.is_not_nil(s)
+    -- _session_order has one entry; global_counts returns offset=0, total=1
+    -- We can't directly call global_counts (private), but we can verify via the session
+    assert.equal(1, #s.hunks)
+  end)
+
+  it("two buffers: second buffer offset = first buffer hunk count", function()
+    local buf1 = make_buf({ "line1" })
+    local buf2 = make_buf({ "a", "b" })
+
+    session.start(buf1, { "orig1" }, opts)        -- 1 hunk in buf1
+    session.start(buf2, { "x", "y" }, opts)       -- 1 hunk in buf2
+
+    local s1 = session.get(buf1)
+    local s2 = session.get(buf2)
+    assert.is_not_nil(s1)
+    assert.is_not_nil(s2)
+    -- session_order is [buf1, buf2]
+    -- buf1: offset=0, total=2 → hunk shows [1/2]
+    -- buf2: offset=1, total=2 → hunk shows [2/2]
+    assert.equal(2, #session._session_order)
+  end)
+
+  it("accepting a hunk decrements global total", function()
+    local buf1 = make_buf({ "new1" })
+    local buf2 = make_buf({ "new2" })
+
+    session.start(buf1, { "old1" }, opts)
+    session.start(buf2, { "old2" }, opts)
+
+    -- Accept the only hunk in buf1
+    local s1 = session.get(buf1)
+    assert.is_not_nil(s1)
+    for _, h in ipairs(s1.hunks) do
+      if h.status == "pending" then
+        require("copilot_hunk.hunk").accept(h)
+      end
+    end
+    -- Now session_order still has buf1 until _check_complete; manually check
+    local s2 = session.get(buf2)
+    assert.is_not_nil(s2)
+    -- buf2 hunk should still be pending
+    local pending = 0
+    for _, h in ipairs(s2.hunks) do
+      if h.status == "pending" then pending = pending + 1 end
+    end
+    assert.equal(1, pending)
+  end)
+
+  it("_render_hunk_counters uses global_offset/global_total when provided", function()
+    local ui = require("copilot_hunk.ui")
+    local ns = ui.ns()
+    local bufnr = make_buf({ "foo", "bar" })
+    -- Simulate a hunk list with one pending hunk
+    local hunks = {
+      { id = 1, type = "change", status = "pending",
+        start_after = 1, end_after = 1,
+        before_lines = { "old" }, after_lines = { "foo" } },
+    }
+    -- With global_offset=2, global_total=5 → should render [3/5]
+    ui.render(bufnr, hunks, opts, 2, 5)
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+    local found = false
+    for _, m in ipairs(marks) do
+      local vt = m[4] and m[4].virt_text
+      if vt then
+        for _, chunk in ipairs(vt) do
+          if chunk[1] == "[3/5]" then found = true end
+        end
+      end
+    end
+    assert.is_true(found, "expected [3/5] in extmarks")
+  end)
+
+  it("_render_hunk_counters falls back to local count when no globals", function()
+    local ui = require("copilot_hunk.ui")
+    local ns = ui.ns()
+    local bufnr = make_buf({ "foo", "bar" })
+    local hunks = {
+      { id = 1, type = "change", status = "pending",
+        start_after = 1, end_after = 1,
+        before_lines = { "old" }, after_lines = { "foo" } },
+      { id = 2, type = "add", status = "pending",
+        start_after = 2, end_after = 2,
+        before_lines = {}, after_lines = { "bar" } },
+    }
+    -- No globals → should render [1/2] and [2/2]
+    ui.render(bufnr, hunks, opts)
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+    local texts = {}
+    for _, m in ipairs(marks) do
+      local vt = m[4] and m[4].virt_text
+      if vt then
+        for _, chunk in ipairs(vt) do
+          if chunk[1]:match("%[%d+/%d+%]") then
+            texts[#texts + 1] = chunk[1]
+          end
+        end
+      end
+    end
+    assert.is_true(vim.tbl_contains(texts, "[1/2]"), "expected [1/2]")
+    assert.is_true(vim.tbl_contains(texts, "[2/2]"), "expected [2/2]")
+  end)
+end)


### PR DESCRIPTION
## 変更概要

### Issue #18: グローバルhunkカウンター
- `[1/n]` の分母が全ファイルの全hunk合計になった
- file1に2hunk・file2に2hunkある場合: file1は `[1/4]``[2/4]`、file2は `[3/4]``[4/4]`
- accept/reject時に `_rerender_all()` で全セッションのカウンターを同期

### Issue #19: ロボットアイコン装飾
- `decoration.lua` 新規作成
- `vim.b[bufnr].copilot_hunk_active = true/false` (statusline/tabline連携)
- `vim.b[bufnr].copilot_hunk_count = N` (pending hunk数)
- diagnostics API (neo-tree/nvim-tree等で自動的に診断アイコン表示)
- `User CopilotHunkSessionChanged` イベント (カスタム統合用)
- opt-in WinBar: `setup({ decorations = { winbar = true } })`
- `require('copilot_hunk').statusline()` ヘルパー

Closes #18
Closes #19