### PR TITLE
fix: 隠しバッファ経由で開いたファイルにシンタックスハイライト・LSPが適用されない問題を修正 (#29)

### DIFF
--- a/lua/copilot_hunk/init.lua
+++ b/lua/copilot_hunk/init.lua
@@ -347,6 +347,15 @@ function M._detect_ai_edited_via_git(_snap_store, last_nvim_write)
     bufnr = vim.fn.bufadd(fullpath)
     vim.bo[bufnr].buflisted = false
     vim.fn.bufload(bufnr)
+    -- Set filetype so syntax/LSP can potentially work even before :edit
+    local ft = vim.filetype.match({ filename = relpath, buf = bufnr })
+    if ft and ft ~= "" then
+      vim.schedule(function()
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          vim.bo[bufnr].filetype = ft
+        end
+      end)
+    end
 
     local current = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     if not vim.deep_equal(base_lines, current) and not M.has_session(bufnr) then
@@ -373,6 +382,15 @@ function M._detect_ai_edited_via_git(_snap_store, last_nvim_write)
     nbufnr = vim.fn.bufadd(fullpath)
     vim.bo[nbufnr].buflisted = false
     vim.fn.bufload(nbufnr)
+    -- Set filetype so syntax/LSP can potentially work even before :edit
+    local nft = vim.filetype.match({ filename = relpath, buf = nbufnr })
+    if nft and nft ~= "" then
+      vim.schedule(function()
+        if vim.api.nvim_buf_is_valid(nbufnr) then
+          vim.bo[nbufnr].filetype = nft
+        end
+      end)
+    end
 
     local new_current = vim.api.nvim_buf_get_lines(nbufnr, 0, -1, false)
     if #new_current == 0 or (#new_current == 1 and new_current[1] == "") then goto cont_new end
@@ -412,6 +430,15 @@ function M._detect_ai_edited_via_git(_snap_store, last_nvim_write)
     dbufnr = vim.fn.bufadd(fullpath)
     vim.bo[dbufnr].buflisted = false
     vim.fn.bufload(dbufnr)
+    -- Set filetype so syntax/LSP can potentially work even before :edit
+    local dft = vim.filetype.match({ filename = relpath, buf = dbufnr })
+    if dft and dft ~= "" then
+      vim.schedule(function()
+        if vim.api.nvim_buf_is_valid(dbufnr) then
+          vim.bo[dbufnr].filetype = dft
+        end
+      end)
+    end
     vim.api.nvim_buf_set_lines(dbufnr, 0, -1, false, {})
 
     if not M.has_session(dbufnr) then

--- a/lua/copilot_hunk/session.lua
+++ b/lua/copilot_hunk/session.lua
@@ -265,12 +265,8 @@ function M.goto_next(bufnr)
   if cross == nil then cross = true end
   local next_bufnr = cross and M._next_session_bufnr(bufnr) or nil
   if next_bufnr and next_bufnr ~= bufnr then
-    -- Restore buflisted for hidden buffers we loaded via git detection
-    if not vim.bo[next_bufnr].buflisted then
-      vim.bo[next_bufnr].buflisted = true
-    end
-    vim.api.nvim_set_current_buf(next_bufnr)
-    local ns = M.get(next_bufnr)
+    local actual_bufnr = M._open_buffer(next_bufnr)
+    local ns = M.get(actual_bufnr)
     if ns then
       local first = hunk_mod.next_hunk(0, ns.hunks)
       if first then
@@ -307,11 +303,8 @@ function M.goto_prev(bufnr)
   if cross == nil then cross = true end
   local prev_bufnr = cross and M._prev_session_bufnr(bufnr) or nil
   if prev_bufnr and prev_bufnr ~= bufnr then
-    if not vim.bo[prev_bufnr].buflisted then
-      vim.bo[prev_bufnr].buflisted = true
-    end
-    vim.api.nvim_set_current_buf(prev_bufnr)
-    local ps = M.get(prev_bufnr)
+    local actual_bufnr = M._open_buffer(prev_bufnr)
+    local ps = M.get(actual_bufnr)
     if ps then
       local last = hunk_mod.prev_hunk(math.huge, ps.hunks)
       if last then
@@ -386,6 +379,61 @@ function M._check_complete(bufnr, session)
 
   M.stop(bufnr)
   vim.notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO)
+end
+
+--- @private
+--- Open a buffer in the current window, using :edit for hidden buffers to
+--- ensure FileType / LSP / Treesitter autocmds fire properly.
+--- Returns the actual bufnr after opening (may differ if :edit creates a new buf).
+--- @param target_bufnr number
+--- @return number  actual bufnr now current
+function M._open_buffer(target_bufnr)
+  local fname = vim.api.nvim_buf_get_name(target_bufnr)
+  local was_hidden = not vim.bo[target_bufnr].buflisted
+
+  if fname ~= "" and was_hidden then
+    if vim.fn.filereadable(fname) == 1 then
+      -- Use :edit to trigger full autocmd chain (BufReadPost, FileType, LSP attach).
+      vim.cmd("edit " .. vim.fn.fnameescape(fname))
+      local cur_bufnr = vim.api.nvim_get_current_buf()
+
+      -- Transfer session data if :edit assigned a different bufnr.
+      if cur_bufnr ~= target_bufnr and M._sessions[target_bufnr] then
+        local s = M._sessions[target_bufnr]
+        s.bufnr = cur_bufnr
+        M._sessions[cur_bufnr] = s
+        M._sessions[target_bufnr] = nil
+
+        for i, b in ipairs(M._session_order) do
+          if b == target_bufnr then
+            M._session_order[i] = cur_bufnr
+            break
+          end
+        end
+
+        -- Re-attach keymaps and re-render on the new bufnr.
+        local off, tot = global_counts(cur_bufnr)
+        ui.render(cur_bufnr, s.hunks, s.opts, off, tot)
+        keymap.attach(cur_bufnr)
+      end
+    else
+      -- File doesn't exist (deleted file buffer): set filetype and switch.
+      vim.bo[target_bufnr].buflisted = true
+      vim.api.nvim_set_current_buf(target_bufnr)
+      -- Trigger FileType manually so syntax highlighting can activate.
+      if vim.bo[target_bufnr].filetype ~= "" then
+        vim.api.nvim_exec_autocmds("FileType", {
+          buffer = target_bufnr,
+          modeline = false,
+        })
+      end
+    end
+    return vim.api.nvim_get_current_buf()
+  else
+    -- Buffer already has correct setup (was buflisted); just switch.
+    vim.api.nvim_set_current_buf(target_bufnr)
+    return target_bufnr
+  end
 end
 
 --- @private


### PR DESCRIPTION
## 概要

隠しバッファ（`bufload`経由で読み込んだAI編集ファイル）へクロスファイルナビゲーション（`n`/`N`）で移動した際、`FileType`・`BufReadPost`等のautocmdが発火せず、**Treesitter（シンタックスハイライト）とLSPがアタッチされない**問題を修正します。

Closes #29

## 原因

`vim.fn.bufload()` + `nvim_set_current_buf()` は `BufEnter` のみ発火し、`FileType`・`BufReadPost` を発火しません。Treesitter・LSPはこれらのイベントに依存してアタッチするため、隠しバッファを直接表示すると機能しません。

## 変更内容

### `lua/copilot_hunk/session.lua`
- **`M._open_buffer(target_bufnr)`** を新規追加
  - 隠しバッファ（`buflisted = false`）かつファイルが存在する場合: `:edit` で開き直し、autocmdチェーン全体を発火
  - `:edit` がbufnrを再割り当てした場合: セッションデータ・キーマップ・UIを新bufnrに移行
  - 削除済みファイル（ディスク上に存在しない）: `buflisted` を復元し `FileType` autocmdを手動発火
  - 既にbuflisted（通常のバッファ）: 従来通り `nvim_set_current_buf()` で切り替え
- **`goto_next`** / **`goto_prev`**: `M._open_buffer()` 経由でバッファを開くように変更

### `lua/copilot_hunk/init.lua`
- `_detect_ai_edited_via_git` 内の3箇所（変更ファイル・新規ファイル・削除ファイル）で `bufload` 直後に `vim.filetype.match()` でfiletypeを設定
- `:edit` で開く前でもシンタックスが効くようにする事前準備