### PR TITLE
fix: accept後の再表示バグ修正 + notify_level設定オプション追加 (closes #31 #32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Thumbs.db
 .idea/
 .vscode/
 *.sublime-*
+
+# copilot-hunk reviewed state (fallback location outside .git/)
+.copilot-hunk-reviewed

--- a/lua/copilot_hunk/init.lua
+++ b/lua/copilot_hunk/init.lua
@@ -16,6 +16,75 @@
 
 local M = {}
 
+--- @private
+--- Conditionally emit a notification based on minimum notify_level.
+--- @param msg string
+--- @param level number  vim.log.levels.*
+--- @param opts? table   plugin opts (uses notify_level field)
+local function _notify(msg, level, opts)
+  local min_level = (opts and opts.notify_level) or vim.log.levels.WARN
+  if level >= min_level then
+    vim.notify(msg, level)
+  end
+end
+
+--- Returns path to the reviewed-state file.
+--- Prefers .git/copilot-hunk-reviewed, falls back to .copilot-hunk-reviewed in cwd.
+local function _state_file_path()
+  local git_dir = vim.fn.finddir(".git", vim.fn.getcwd() .. ";")
+  if git_dir and git_dir ~= "" then
+    return vim.fn.fnamemodify(git_dir, ":p") .. "copilot-hunk-reviewed"
+  end
+  return vim.fn.getcwd() .. "/.copilot-hunk-reviewed"
+end
+
+--- Load the reviewed state from disk → { [relpath] = sha256_hash }
+local function _load_reviewed_state()
+  local path = _state_file_path()
+  local state = {}
+  if vim.fn.filereadable(path) == 0 then return state end
+  for _, line in ipairs(vim.fn.readfile(path)) do
+    local rel, hash = line:match("^(.+):([a-f0-9]+)$")
+    if rel and hash then state[rel] = hash end
+  end
+  return state
+end
+
+--- Save the reviewed state to disk.
+local function _save_reviewed_state(state)
+  local path = _state_file_path()
+  local lines = {}
+  for rel, hash in pairs(state) do
+    lines[#lines + 1] = rel .. ":" .. hash
+  end
+  vim.fn.writefile(lines, path)
+end
+
+--- Mark a file as reviewed (called after session completes).
+--- @param fullpath string  absolute path
+function M._mark_reviewed(fullpath)
+  local cwd = vim.fn.getcwd()
+  local relpath = fullpath:sub(#cwd + 2)  -- strip cwd + separator
+  if vim.fn.filereadable(fullpath) == 0 then return end  -- deleted file, skip
+  local lines = vim.fn.readfile(fullpath)
+  local hash = vim.fn.sha256(table.concat(lines, "\n"))
+  local state = _load_reviewed_state()
+  state[relpath] = hash
+  _save_reviewed_state(state)
+end
+
+--- Return true if the file has already been reviewed with its current content.
+--- @param fullpath string
+--- @param relpath string
+local function _is_reviewed(fullpath, relpath)
+  if vim.fn.filereadable(fullpath) == 0 then return false end
+  local state = _load_reviewed_state()
+  if not state[relpath] then return false end
+  local lines = vim.fn.readfile(fullpath)
+  local hash = vim.fn.sha256(table.concat(lines, "\n"))
+  return hash == state[relpath]
+end
+
 --- Default configuration.
 M._opts = {
   highlights = {
@@ -27,6 +96,7 @@ M._opts = {
   keymaps = true,
   enable_auto_snapshot = true,
   cross_file_navigation = true,
+  notify_level = vim.log.levels.WARN,
   decorations = {
     winbar = false,   -- opt-in WinBar (may conflict with other winbar plugins)
     icon   = "🤖",   -- icon shown in WinBar / statusline
@@ -124,7 +194,7 @@ function M.arm(bufnr)
       if not vim.deep_equal(base, current) then
         require("copilot_hunk.session").start(bufnr, base, M._opts)
       else
-        vim.notify("[copilot-hunk] 変更が検出されませんでした。", vim.log.levels.INFO)
+        _notify("[copilot-hunk] 変更が検出されませんでした。", vim.log.levels.INFO, M._opts)
       end
     end, 80)
   end
@@ -148,9 +218,9 @@ function M.arm(bufnr)
   M._armed = M._armed or {}
   M._armed[bufnr] = { base = base, aug = aug_name, timer = timer, fname = fname }
 
-  vim.notify(
+  _notify(
     string.format("[copilot-hunk] Armed: %s — AIが編集したら自動でセッション開始します", vim.fn.fnamemodify(fname, ":t")),
-    vim.log.levels.INFO
+    vim.log.levels.INFO, M._opts
   )
 end
 
@@ -330,6 +400,9 @@ function M._detect_ai_edited_via_git(_snap_store, last_nvim_write)
     local already_loaded = bufnr ~= -1 and vim.api.nvim_buf_is_loaded(bufnr)
     if already_loaded then goto continue end
 
+    -- Skip if already reviewed with current content
+    if _is_reviewed(fullpath, relpath) then goto continue end
+
     -- Formatter guard: skip if recently written by Neovim
     if bufnr ~= -1 and last_nvim_write[bufnr] then
       if (now - last_nvim_write[bufnr]) < 2000 then goto continue end
@@ -373,6 +446,9 @@ function M._detect_ai_edited_via_git(_snap_store, last_nvim_write)
   for _, relpath in ipairs(new_files or {}) do
     local fullpath = cwd .. "/" .. relpath
     if vim.fn.filereadable(fullpath) == 0 then goto cont_new end
+
+    -- Skip if already reviewed with current content
+    if _is_reviewed(fullpath, relpath) then goto cont_new end
 
     local nbufnr = vim.fn.bufnr(fullpath)
     local nloaded = nbufnr ~= -1 and vim.api.nvim_buf_is_loaded(nbufnr)

--- a/lua/copilot_hunk/session.lua
+++ b/lua/copilot_hunk/session.lua
@@ -9,6 +9,18 @@ local keymap     = require("copilot_hunk.keymap")
 local decoration = require("copilot_hunk.decoration")
 
 --- @private
+--- Conditionally emit a notification based on minimum notify_level.
+--- @param msg string
+--- @param level number  vim.log.levels.*
+--- @param opts? table   session opts (uses notify_level field)
+local function _notify(msg, level, opts)
+  local min_level = (opts and opts.notify_level) or vim.log.levels.WARN
+  if level >= min_level then
+    vim.notify(msg, level)
+  end
+end
+
+--- @private
 --- Calculate the global hunk offset and total across all active sessions.
 --- Counts non-rejected hunks (pending + accepted) to keep counter stable
 --- until a hunk is explicitly rejected.
@@ -70,7 +82,7 @@ function M.start(bufnr, base_lines, opts)
 
   local hunks = diff_mod.diff(base_lines, ai_result_lines)
   if #hunks == 0 then
-    vim.notify("[copilot-hunk] No differences found.", vim.log.levels.INFO)
+    _notify("[copilot-hunk] No differences found.", vim.log.levels.INFO, opts)
     return false
   end
 
@@ -97,9 +109,9 @@ function M.start(bufnr, base_lines, opts)
     end,
   })
 
-  vim.notify(
+  _notify(
     string.format("[copilot-hunk] Review started: %d hunk(s) to review.", #hunks),
-    vim.log.levels.INFO
+    vim.log.levels.INFO, opts
   )
   return true
 end
@@ -146,7 +158,7 @@ function M.accept_at_cursor(bufnr)
   local line = vim.api.nvim_win_get_cursor(0)[1]  -- 1-indexed
   local hunk = hunk_mod.hunk_at_line(line, session.hunks)
   if not hunk then
-    vim.notify("[copilot-hunk] No pending hunk at cursor.", vim.log.levels.INFO)
+    _notify("[copilot-hunk] No pending hunk at cursor.", vim.log.levels.INFO, session.opts)
     return
   end
 
@@ -176,7 +188,7 @@ function M.reject_at_cursor(bufnr)
   local line = vim.api.nvim_win_get_cursor(0)[1]
   local hunk = hunk_mod.hunk_at_line(line, session.hunks)
   if not hunk then
-    vim.notify("[copilot-hunk] No pending hunk at cursor.", vim.log.levels.INFO)
+    _notify("[copilot-hunk] No pending hunk at cursor.", vim.log.levels.INFO, session.opts)
     return
   end
 
@@ -280,7 +292,7 @@ function M.goto_next(bufnr)
   if hunk then
     vim.api.nvim_win_set_cursor(0, { hunk.start_after, 0 })
   else
-    vim.notify("[copilot-hunk] No pending hunks.", vim.log.levels.INFO)
+    _notify("[copilot-hunk] No pending hunks.", vim.log.levels.INFO, session.opts)
   end
 end
 
@@ -318,7 +330,7 @@ function M.goto_prev(bufnr)
   if hunk then
     vim.api.nvim_win_set_cursor(0, { hunk.start_after, 0 })
   else
-    vim.notify("[copilot-hunk] No pending hunks.", vim.log.levels.INFO)
+    _notify("[copilot-hunk] No pending hunks.", vim.log.levels.INFO, session.opts)
   end
 end
 
@@ -328,6 +340,15 @@ end
 function M._check_complete(bufnr, session)
   for _, h in ipairs(session.hunks) do
     if h.status == "pending" then return end
+  end
+
+  -- Mark the file as reviewed so it won't re-trigger in a new session
+  local mark_path = (session.opts and session.opts._session_file_path)
+                 or vim.api.nvim_buf_get_name(bufnr)
+  if mark_path and mark_path ~= "" then
+    pcall(function()
+      require("copilot_hunk")._mark_reviewed(mark_path)
+    end)
   end
 
   -- FS operations for new/deleted file sessions (before stop clears session state)
@@ -352,7 +373,7 @@ function M._check_complete(bufnr, session)
         end)
         M.stop(bufnr)
       end
-      vim.notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO)
+      _notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO, session.opts)
       return
     elseif kind == "deleted_file" then
       if not is_empty then
@@ -371,14 +392,14 @@ function M._check_complete(bufnr, session)
         if vim.api.nvim_buf_is_valid(bufnr) then
           vim.api.nvim_buf_delete(bufnr, { force = true })
         end
-        vim.notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO)
+        _notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO, session.opts)
         return
       end
     end
   end
 
   M.stop(bufnr)
-  vim.notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO)
+  _notify("[copilot-hunk] All hunks reviewed. Session ended.", vim.log.levels.INFO, session.opts)
 end
 
 --- @private


### PR DESCRIPTION
## 概要

Issue #31 と #32 を修正します。

### #31 — accept後に別セッションで再度hunkが表示されるバグ

**原因**: `_detect_ai_edited_via_git` は `git diff --name-only HEAD` で変更ファイルを検出するため、accept後もコミットされていないファイルが再検出されていました。

**修正**: `.git/copilot-hunk-reviewed` にファイルのSHA-256ハッシュを保存し、セッション開始前にチェック。ハッシュが一致すれば（= 内容が変わっていなければ）スキップします。AIが再度編集するとハッシュが変わるため、新しいセッションが正しく表示されます。

### #32 — notify通知の削減・設定可能化

**修正**: `notify_level` オプション（デフォルト: `vim.log.levels.WARN`）を追加。INFO レベルの通知（"Review started"、"No differences found" 等）がデフォルトで抑制されます。

従来通りの通知を表示するには:
```lua
require("copilot_hunk").setup({ notify_level = vim.log.levels.INFO })
```

### 変更ファイル
- `lua/copilot_hunk/init.lua` — reviewed state ヘルパー関数、`_notify` ヘルパー、`notify_level` オプション追加
- `lua/copilot_hunk/session.lua` — `_notify` ヘルパー追加、`_check_complete` で `_mark_reviewed` 呼び出し
- `.gitignore` — `.copilot-hunk-reviewed` を追加（フォールバック用）

Closes #31, Closes #32