### PR TITLE
fix: accept/reject後のクロスファイルナビ修正 + diagnostic通知抑制 (#34 #35)

### DIFF
--- a/lua/copilot_hunk/decoration.lua
+++ b/lua/copilot_hunk/decoration.lua
@@ -9,6 +9,17 @@ local _ns = nil  -- diagnostic namespace
 --- Initialize decoration subsystem. Called from setup().
 function M.setup()
   _ns = vim.api.nvim_create_namespace("copilot_hunk_diag")
+  -- Suppress ALL visual output for our diagnostic namespace.
+  -- The entries exist only so nvim-tree / neo-tree / statusline can read them
+  -- via vim.diagnostic.get(). No popups, no signs, no virtual text ever.
+  vim.diagnostic.config({
+    virtual_text     = false,
+    signs            = false,
+    underline        = false,
+    float            = false,
+    update_in_insert = false,
+    severity_sort    = false,
+  }, _ns)
 end
 
 --- Mark a buffer as having AI-pending hunks.
@@ -32,7 +43,7 @@ function M.mark(bufnr, pending_count, opts)
         message  = string.format("AI変更あり (%d hunk)", pending_count),
         source   = "copilot-hunk",
       },
-    }, { virtual_text = false, signs = false, underline = false })
+    })
   end
 
   local show_winbar = opts.decorations and opts.decorations.winbar

--- a/lua/copilot_hunk/session.lua
+++ b/lua/copilot_hunk/session.lua
@@ -162,6 +162,11 @@ function M.accept_at_cursor(bufnr)
     return
   end
 
+  -- Save cross-file nav target BEFORE _check_complete may stop this session.
+  local cross = session.opts and session.opts.cross_file_navigation
+  if cross == nil then cross = true end
+  local next_bufnr_for_nav = cross and M._next_session_bufnr(bufnr) or nil
+
   hunk_mod.accept(hunk)
   local off, tot = global_counts(bufnr)
   ui.render(bufnr, session.hunks, session.opts, off, tot)
@@ -174,8 +179,20 @@ function M.accept_at_cursor(bufnr)
     for _, h in ipairs(upd_s.hunks) do if h.status == "pending" then pend = pend + 1 end end
     decoration.update(bufnr, pend, upd_s.opts)
   end
+
   if M.get(bufnr) then
+    -- Session still active: navigate within current file.
     M.goto_next(bufnr)
+  elseif next_bufnr_for_nav and next_bufnr_for_nav ~= bufnr then
+    -- Session ended (last hunk resolved): jump to first hunk of next file.
+    local actual = M._open_buffer(next_bufnr_for_nav)
+    local ns = M.get(actual)
+    if ns then
+      local first = hunk_mod.next_hunk(0, ns.hunks)
+      if first then
+        vim.api.nvim_win_set_cursor(0, { first.start_after, 0 })
+      end
+    end
   end
 end
 
@@ -192,6 +209,11 @@ function M.reject_at_cursor(bufnr)
     return
   end
 
+  -- Save cross-file nav target BEFORE _check_complete may stop this session.
+  local cross = session.opts and session.opts.cross_file_navigation
+  if cross == nil then cross = true end
+  local next_bufnr_for_nav = cross and M._next_session_bufnr(bufnr) or nil
+
   hunk_mod.reject(hunk, bufnr, session.hunks)
   local off, tot = global_counts(bufnr)
   ui.render(bufnr, session.hunks, session.opts, off, tot)
@@ -204,8 +226,20 @@ function M.reject_at_cursor(bufnr)
     for _, h in ipairs(upd_s2.hunks) do if h.status == "pending" then pend = pend + 1 end end
     decoration.update(bufnr, pend, upd_s2.opts)
   end
+
   if M.get(bufnr) then
+    -- Session still active: navigate within current file.
     M.goto_next(bufnr)
+  elseif next_bufnr_for_nav and next_bufnr_for_nav ~= bufnr then
+    -- Session ended (last hunk resolved): jump to first hunk of next file.
+    local actual = M._open_buffer(next_bufnr_for_nav)
+    local ns = M.get(actual)
+    if ns then
+      local first = hunk_mod.next_hunk(0, ns.hunks)
+      if first then
+        vim.api.nvim_win_set_cursor(0, { first.start_after, 0 })
+      end
+    end
   end
 end
 

--- a/spec/cross_file_spec.lua
+++ b/spec/cross_file_spec.lua
@@ -152,4 +152,74 @@ describe("cross-file navigation", function()
       assert.equal(0, #session._session_order)
     end)
   end)
+
+  -- ── cross-file jump after accept/reject last hunk (#34) ────────────────
+
+  describe("accept/reject last hunk cross-file jump", function()
+    it("accept last hunk in file1 jumps to file2", function()
+      local buf1 = make_buf({ "a", "b" }, "/tmp/ch_test_accept_jump1.txt")
+      local buf2 = make_buf({ "x", "y" }, "/tmp/ch_test_accept_jump2.txt")
+
+      session.start(buf1, { "a_old", "b" }, init._opts)
+      session.start(buf2, { "x_old", "y" }, init._opts)
+
+      -- Set cursor onto buf1's first hunk
+      vim.api.nvim_set_current_buf(buf1)
+      local s1 = session.get(buf1)
+      vim.api.nvim_win_set_cursor(0, { s1.hunks[1].start_after, 0 })
+
+      -- Accept the only hunk in buf1
+      session.accept_at_cursor(buf1)
+
+      -- buf1 session should be stopped
+      assert.is_nil(session.get(buf1))
+      -- buf2 session should still be active
+      assert.is_not_nil(session.get(buf2))
+      -- Current buffer should now be buf2 (cross-file jump)
+      assert.equal(buf2, vim.api.nvim_get_current_buf())
+    end)
+
+    it("reject last hunk in file1 jumps to file2", function()
+      local buf1 = make_buf({ "a", "b" }, "/tmp/ch_test_reject_jump1.txt")
+      local buf2 = make_buf({ "x", "y" }, "/tmp/ch_test_reject_jump2.txt")
+
+      session.start(buf1, { "a_old", "b" }, init._opts)
+      session.start(buf2, { "x_old", "y" }, init._opts)
+
+      -- Set cursor onto buf1's first hunk
+      vim.api.nvim_set_current_buf(buf1)
+      local s1 = session.get(buf1)
+      vim.api.nvim_win_set_cursor(0, { s1.hunks[1].start_after, 0 })
+
+      -- Reject the only hunk in buf1
+      session.reject_at_cursor(buf1)
+
+      -- buf1 session should be stopped
+      assert.is_nil(session.get(buf1))
+      -- buf2 session should still be active
+      assert.is_not_nil(session.get(buf2))
+      -- Current buffer should now be buf2 (cross-file jump)
+      assert.equal(buf2, vim.api.nvim_get_current_buf())
+    end)
+
+    it("no cross-file jump when cross_file_navigation is false", function()
+      local opts_no_cross = vim.tbl_deep_extend("force", init._opts, { cross_file_navigation = false })
+      local buf1 = make_buf({ "a", "b" }, "/tmp/ch_test_no_jump1.txt")
+      local buf2 = make_buf({ "x", "y" }, "/tmp/ch_test_no_jump2.txt")
+
+      session.start(buf1, { "a_old", "b" }, opts_no_cross)
+      session.start(buf2, { "x_old", "y" }, opts_no_cross)
+
+      vim.api.nvim_set_current_buf(buf1)
+      local s1 = session.get(buf1)
+      vim.api.nvim_win_set_cursor(0, { s1.hunks[1].start_after, 0 })
+
+      session.accept_at_cursor(buf1)
+
+      -- buf1 session should be stopped
+      assert.is_nil(session.get(buf1))
+      -- Current buffer stays on buf1 (no cross-file jump)
+      assert.equal(buf1, vim.api.nvim_get_current_buf())
+    end)
+  end)
 end)

--- a/spec/decoration_spec.lua
+++ b/spec/decoration_spec.lua
@@ -1,0 +1,54 @@
+--- spec/decoration_spec.lua
+--- Tests for decoration.lua diagnostic namespace config (Issue #35).
+
+describe("decoration", function()
+  local init, decoration
+
+  before_each(function()
+    for _, mod in ipairs({
+      "copilot_hunk", "copilot_hunk.session", "copilot_hunk.ui",
+      "copilot_hunk.diff", "copilot_hunk.hunk", "copilot_hunk.keymap", "copilot_hunk.decoration"
+    }) do
+      package.loaded[mod] = nil
+    end
+    init = require("copilot_hunk")
+    decoration = require("copilot_hunk.decoration")
+    init.setup({ enable_auto_snapshot = false, keymaps = false, signs = false, highlights = {} })
+  end)
+
+  it("setup configures diagnostic namespace to suppress all visuals", function()
+    local ns = vim.api.nvim_create_namespace("copilot_hunk_diag")
+    local cfg = vim.diagnostic.config(nil, ns)
+    assert.is_false(cfg.virtual_text)
+    assert.is_false(cfg.signs)
+    assert.is_false(cfg.underline)
+    assert.is_false(cfg.float)
+    assert.is_false(cfg.update_in_insert)
+    assert.is_false(cfg.severity_sort)
+  end)
+
+  it("mark sets one diagnostic entry for the buffer", function()
+    local bufnr = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "hello" })
+
+    decoration.mark(bufnr, 2, {})
+
+    local ns = vim.api.nvim_create_namespace("copilot_hunk_diag")
+    local diags = vim.diagnostic.get(bufnr, { namespace = ns })
+    assert.equal(1, #diags)
+    assert.equal(vim.diagnostic.severity.HINT, diags[1].severity)
+    assert.truthy(diags[1].message:find("2 hunk"))
+  end)
+
+  it("unmark clears diagnostics for the buffer", function()
+    local bufnr = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "hello" })
+
+    decoration.mark(bufnr, 1, {})
+    decoration.unmark(bufnr, {})
+
+    local ns = vim.api.nvim_create_namespace("copilot_hunk_diag")
+    local diags = vim.diagnostic.get(bufnr, { namespace = ns })
+    assert.equal(0, #diags)
+  end)
+end)


### PR DESCRIPTION
## 概要

Issues #34 と #35 を修正します。

### #34 — accept/rejectで最後のhunkを解消後に次ファイルへジャンプしないバグ

**原因**: `accept_at_cursor` / `reject_at_cursor` で `_check_complete` が最後の hunk 解消時にセッションを `stop` した後、`M.get(bufnr)` が nil を返すため `goto_next` が呼ばれない。

**修正**: `_check_complete` 呼び出し前に `_next_session_bufnr` で次ファイルの bufnr を保存し、セッション終了後にそのバッファへジャンプする。

### #35 — decoration.luaのdiagnostic通知をnamespace configで完全抑制

**原因**: `vim.diagnostic.config()` が namespace に対して未設定のため、グローバルデフォルト（`float = true` 等）が適用され、nvim-notify 等がポップアップを表示していた。

**修正**: `M.setup()` で namespace に対して全ての表示オプションを `false` に設定。`vim.diagnostic.set()` の冗長な opts 引数も削除。

## テスト

- `spec/cross_file_spec.lua` にクロスファイルジャンプテスト 3件追加
- `spec/decoration_spec.lua` を新規作成（namespace config 検証 + mark/unmark テスト）
- 全 87 テスト通過、luacheck 警告/エラー 0

Closes #34
Closes #35