### PR TITLE
fix: accept後もhunkが消えない + ui.lua col out of range エラー修正 (closes #39)

### DIFF
--- a/lua/copilot_hunk/ui.lua
+++ b/lua/copilot_hunk/ui.lua
@@ -76,7 +76,7 @@ function M.render(bufnr, hunks, opts, global_offset, global_total)
   local show_signs = opts and opts.signs ~= false
 
   for _, hunk in ipairs(hunks) do
-    if hunk.status ~= "rejected" then
+    if hunk.status == "pending" then
       M._render_hunk(bufnr, ns, hunk, show_signs)
     end
   end
@@ -193,17 +193,21 @@ function M._render_char_diff(bufnr, ns, hunk)
     for _, idx in ipairs(indices) do
       local start_a, count_a = idx[3], idx[4]
       if count_a > 0 then
+        -- Get actual buffer line at this row
+        local actual_line = (vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false) or {})[1] or ""
+        local actual_len = #actual_line
+
         local col_start = start_a - 1  -- 0-indexed
         local col_end   = col_start + count_a
-        -- Clamp to actual line length
-        local line_len = #after
-        col_end = math.min(col_end, line_len)
+        -- Clamp both start and end to actual buffer line length
+        col_end   = math.min(col_end, actual_len)
+        col_start = math.min(col_start, actual_len)
         if col_start < col_end then
           vim.api.nvim_buf_set_extmark(bufnr, ns, row, col_start, {
-            end_row   = row,
-            end_col   = col_end,
-            hl_group  = "CopilotHunkChangeChar",
-            priority  = 120,
+            end_row  = row,
+            end_col  = col_end,
+            hl_group = "CopilotHunkChangeChar",
+            priority = 120,
           })
         end
       end

--- a/spec/ui_spec.lua
+++ b/spec/ui_spec.lua
@@ -1,0 +1,111 @@
+local ui
+
+before_each(function()
+  for _, mod in ipairs({
+    "copilot_hunk", "copilot_hunk.ui",
+  }) do
+    package.loaded[mod] = nil
+  end
+  ui = require("copilot_hunk.ui")
+  ui.define_highlights()
+end)
+
+--- Helper: create a scratch buffer with given lines.
+local function make_buf(lines)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  return bufnr
+end
+
+--- Helper: build a minimal hunk table.
+local function make_hunk(opts)
+  return {
+    id           = opts.id or 1,
+    type         = opts.type or "add",
+    status       = opts.status or "pending",
+    start_before = opts.start_before or 0,
+    end_before   = opts.end_before or 0,
+    start_after  = opts.start_after or 1,
+    end_after    = opts.end_after or 1,
+    before_lines = opts.before_lines or {},
+    after_lines  = opts.after_lines or {},
+  }
+end
+
+local OPTS = { signs = false }
+
+-- ──────────────────────────────────────────────
+-- Bug A: accepted/rejected hunks should NOT be rendered
+-- ──────────────────────────────────────────────
+
+describe("ui.render – hunk visibility by status", function()
+  it("renders extmarks for a pending hunk", function()
+    local buf = make_buf({ "hello" })
+    local ns  = ui.ns()
+    local hunks = {
+      make_hunk({ id = 1, type = "add", status = "pending", start_after = 1, end_after = 1, after_lines = { "hello" } }),
+    }
+    ui.render(buf, hunks, OPTS)
+    local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, {})
+    assert.is_true(#marks > 0, "pending hunk should create extmarks")
+  end)
+
+  it("does NOT render extmarks for an accepted hunk", function()
+    local buf = make_buf({ "hello" })
+    local ns  = ui.ns()
+    local hunks = {
+      make_hunk({ id = 1, type = "add", status = "accepted", start_after = 1, end_after = 1, after_lines = { "hello" } }),
+    }
+    ui.render(buf, hunks, OPTS)
+    local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, {})
+    assert.are.equal(0, #marks, "accepted hunk must not produce extmarks")
+  end)
+
+  it("does NOT render extmarks for a rejected hunk", function()
+    local buf = make_buf({ "hello" })
+    local ns  = ui.ns()
+    local hunks = {
+      make_hunk({ id = 1, type = "add", status = "rejected", start_after = 1, end_after = 1, after_lines = { "hello" } }),
+    }
+    ui.render(buf, hunks, OPTS)
+    local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, {})
+    assert.are.equal(0, #marks, "rejected hunk must not produce extmarks")
+  end)
+end)
+
+-- ──────────────────────────────────────────────
+-- Bug B: col out of range in _render_char_diff
+-- ──────────────────────────────────────────────
+
+describe("ui._render_char_diff – col clamping", function()
+  it("does not error when after_lines is longer than the actual buffer line", function()
+    -- Buffer has a short line; hunk's after_lines claims a longer one.
+    local buf = make_buf({ "ab" })  -- actual length = 2
+    local ns  = ui.ns()
+    local hunk = make_hunk({
+      type         = "change",
+      start_after  = 1,
+      end_after    = 1,
+      before_lines = { "xy" },
+      after_lines  = { "abcdefghij" },  -- length = 10, much longer than buffer
+    })
+    -- Should not raise E5108
+    local ok, err = pcall(ui._render_char_diff, buf, ns, hunk)
+    assert.is_true(ok, "expected no error, got: " .. tostring(err))
+  end)
+
+  it("still highlights chars when buffer line matches after_lines length", function()
+    local buf = make_buf({ "abcdef" })
+    local ns  = ui.ns()
+    local hunk = make_hunk({
+      type         = "change",
+      start_after  = 1,
+      end_after    = 1,
+      before_lines = { "aXcdef" },
+      after_lines  = { "abcdef" },
+    })
+    ui._render_char_diff(buf, ns, hunk)
+    local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, {})
+    assert.is_true(#marks > 0, "should have char-level extmarks")
+  end)
+end)


### PR DESCRIPTION
## Summary

Fixes two bugs in `lua/copilot_hunk/ui.lua` reported in #39.

### Bug A: accepted hunks still highlighted
`render()` was filtering `~= "rejected"`, so accepted hunks kept their extmarks.
**Fix**: only render `"pending"` hunks. (`global_counts` in `session.lua` intentionally still counts `~= "rejected"`.)

### Bug B: `E5108: Invalid col out of range`
`_render_char_diff()` clamped `col_end` against `#after` (hunk text length) instead of the actual buffer line length. After a reject, buffer content can be shorter than `after_lines`, causing `col_start` to exceed the real line length.
**Fix**: clamp both `col_start` and `col_end` against the actual buffer line length via `nvim_buf_get_lines`.

### Tests
Added `spec/ui_spec.lua` covering:
- Pending hunk → extmarks present
- Accepted hunk → no extmarks
- Rejected hunk → no extmarks
- `_render_char_diff` with after_lines longer than buffer → no error
- Normal char diff still highlights correctly