### PR TITLE
docs: README/SPEC/CHANGELOG を v0.3.6 相当に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-03-19
+## [0.3.6] - 2026-03-20
+### Fixed
+- Accept後もhunkハイライトが消えないバグを修正 (`render()` が accepted hunks も描画していた)
+- `ui.lua` の `col out of range` エラーを修正 (reject後バッファ行長変化時に col_start が範囲外)
 
+## [0.3.5] - 2026-03-20
+### Fixed
+- Telescope/FZF/nvim-tree でファイルを開いたときhunkが表示されない問題を修正
+- hidden buffer と listed buffer の重複を解消 (`_transfer_session`)
+- `BufEnter` ハンドラを3ケース対応に拡張 (既存session再描画、path-based転送、通常フロー)
+
+## [0.3.4] - 2026-03-20
+### Fixed
+- accept後に別Neovimセッション（別WezTermタブ等）で同じhunkが再表示されるバグを修正
+- `.git/copilot-hunk-reviewed` にSHA-256ハッシュを永続保存、次回起動時にスキップ
+### Added
+- `notify_level` オプション追加（デフォルト: `vim.log.levels.WARN`）
+- INFO通知（"Review started", "No pending hunks" 等）をデフォルトで抑制
+
+## [0.3.3] - 2026-03-20
+### Fixed
+- `n`/`N` で移動して開いたバッファにシンタックスハイライトとLSPが適用されない問題を修正
+- `_open_buffer()` で `:edit` 経由でバッファを開くことで完全なautocmdチェーンを発火
+
+## [0.3.2] - 2026-03-20
+### Added
+- AIが新規作成したファイルの検出・accept/rejectに対応（accept=保存、reject=削除）
+- AIが削除したファイルの検出・accept/rejectに対応（accept=削除、reject=復元）
+- `git ls-files --others` / `git ls-files --deleted` による新規/削除ファイル検出
+### Fixed
+- `diff({}, lines)` / `diff(lines, {})` のエッジケース修正
+
+## [0.3.1] - 2026-03-19
+### Added
+- `cross_file_navigation` オプション追加（デフォルト: true）
+- 未ロードバッファを `git diff --name-only HEAD` で検出しグローバルカウンターに反映
+- `[1/2]` のようにすべてのAI変更ファイルにまたがったグローバルhunkカウンター
+
+## [0.3.0] - 2026-03-19
+### Fixed
+- 非アクティブバッファへのAI変更が検出されないバグを修正
+- タイミング起因のバグ（保存後すぐのchecktime等）を修正
+### Added
+- `BufEnter` ハンドラ：非アクティブバッファへの変更を checktime で検出
+
+## [0.2.0] - 2026-03-19
+### Added
+- グローバルhunkカウンター（全AIファイルにわたる `[1/4]` 表示）
+- ロボアイコン🤖 デコレーション (nvim-tree/neo-tree/statusline連携)
+- `decoration.statusline_component()` — lualine等での `🤖 N` 表示
+- `User CopilotHunkSessionChanged` autocmdイベント
+- `vim.b.copilot_hunk_active` / `vim.b.copilot_hunk_count` バッファ変数
+- `decorations.winbar` オプション
+
+## [0.1.0] - 2026-03-19
 ### Added
 - Initial release
 - Inline diff display with full-line highlighting (VSCode-style)
 - Hunk-level Accept / Reject operations
-- Session-based state management (base / ai_result / current)
-- Virtual lines for displaying deleted lines inline
-- Buffer-local keymaps: `ga`, `gr`, `gn`, `gp`, `gA`, `gR`
+- Auto-detection via FileChangedShell / FocusGained
+- Formatter false-positive guard (BufWritePre 2-second timestamp)
+- Virtual lines for deleted content inline display
+- Character-level diff highlighting within change hunks
+- 2-tier colouring: muted line background + vivid text overlay
+- Buffer-local keymaps: `n`, `N`, `ga`, `gr`, `gA`, `gR`, `gAA`, `gRR`
 - User commands: `:CopilotHunkAccept`, `:CopilotHunkReject`, etc.
+- Cross-file navigation with `_session_order`
 - Git-independent diff engine via `vim.diff()`
+- Neovim ≥ 0.11 requirement

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,19 +15,35 @@ VS Code の GitHub Copilot と同じ体験を Neovim で。
 
 - **AI 編集の自動検出** — 手動のスナップショット操作は不要。
   外部ツールがファイルを書き換えると `FileChangedShell` / `FocusGained` が発火し、
-  レビューセッションが自動的に開始されます。
+  レビューセッションが自動的に開始されます。未ロードバッファも `FocusGained` 時に
+  `git diff` / `git ls-files` で検出されます。
 - **フォーマッタ誤検知防止** — `BufWritePre` タイムスタンプガードにより、
   Neovim の保存から 2 秒以内のファイル変更は無視します (stylua、prettier、LSP format など)。
 - **2 段階カラーリングのインライン diff** — 変更行全体に薄い背景色、
   変更テキスト領域に濃いオーバーレイ (GitHub の diff 表示と同様)。
 - **文字レベル diff** — change hunk 内では、実際に変更された文字が
   さらに濃い色 (`CopilotHunkChangeChar`) でハイライトされます。
-- **Hunk カウンター** — 各 pending hunk の行末に `[1/3]` の仮想テキストを表示。
+- **Hunk カウンター** — 各 pending hunk の行末に `[1/4]` の仮想テキストを表示
+  (全ファイルにわたるグローバルカウンター)。
 - **`n` / `N` ナビゲーション (ラップアラウンド)** — 検索と同じ感覚で hunk 間を移動。
 - **クロスファイルナビゲーション** — 複数ファイルにアクティブセッションがある場合、
   `n` / `N` でバッファ境界を越えて全 pending hunk を巡回します。
+- **新規ファイル / 削除ファイル対応** — AI が新規作成したファイルは全内容が「追加」hunk として表示
+  (accept = 保存、reject = 削除)。AI が削除したファイルは全内容が「削除」hunk として表示
+  (accept = 削除、reject = 復元)。
 - **3 レベルの Accept / Reject** — hunk 単位 (`ga` / `gr`)、ファイル単位 (`gA` / `gR`)、
-  全ファイル (`gAA` / `gRR`)。
+  全ファイル (`gAA` / `gRR`)。accept/reject 後、hunk ハイライトは即座に消え、
+  次の pending hunk へ自動ジャンプします (ファイルをまたいでも対応)。
+- **ロボットアイコン 🤖 デコレーション** — pending hunk のあるバッファに HINT 診断を設定し、
+  nvim-tree / neo-tree が自動で 🤖 アイコンを表示。
+  lualine 連携用の `statusline_component()` も提供します。
+- **通知レベル制御** — `notify_level` オプション (デフォルト `WARN`) で
+  日常的な INFO 通知を抑制し、静かな操作感を実現します。
+- **レビュー済み永続化** — ファイルの全 hunk が解決されると、ファイルパスと SHA-256 ハッシュが
+  `.git/copilot-hunk-reviewed` に保存されます。次回セッション開始時に一致すればスキップ。
+  AI が再編集するとハッシュが変わり自動的に再検出されます。
+- **Telescope / FZF / nvim-tree 互換** — Telescope や FZF で開いたファイルに
+  pending hunk がある場合、セッションが新しいバッファへ自動転送されます。
 - **Git 非依存** — Git リポジトリがなくても動作します。
 
 ---
@@ -64,13 +80,19 @@ use {
 
 ```lua
 require("copilot_hunk").setup({
-  enable_auto_snapshot = true,   -- AI のファイル編集を自動検出
-  signs   = false,               -- サイン列マーカー (デフォルト: false)
-  keymaps = true,                -- デフォルトキーマップを設定
+  enable_auto_snapshot = true,     -- AI のファイル編集を自動検出 (デフォルト: true)
+  signs   = false,                 -- サイン列マーカー (デフォルト: false)
+  keymaps = true,                  -- デフォルトキーマップを設定 (デフォルト: true)
+  cross_file_navigation = true,    -- n/N でファイル間移動 (デフォルト: true)
+  notify_level = vim.log.levels.WARN,  -- 通知レベル (デフォルト: WARN)
+  decorations = {
+    winbar = false,                -- WinBar 表示 (デフォルト: false)
+    icon   = "🤖",                -- WinBar / statusline のアイコン
+  },
   highlights = {
-    add    = {},   -- CopilotHunkAdd の背景色を上書き
-    delete = {},   -- CopilotHunkDelete の背景色を上書き
-    change = {},   -- CopilotHunkChange の背景色を上書き
+    add    = {},                   -- CopilotHunkAdd の背景色を上書き
+    delete = {},                   -- CopilotHunkDelete の背景色を上書き
+    change = {},                   -- CopilotHunkChange の背景色を上書き
   },
 })
 ```
@@ -119,6 +141,34 @@ end)
 | `:CopilotHunkAcceptAllFiles` | 全アクティブセッションの全 hunk を accept |
 | `:CopilotHunkRejectAllFiles` | 全アクティブセッションの全 hunk を reject |
 | `:CopilotHunkEnd` | 現在のセッションを終了 |
+
+---
+
+## 連携
+
+### ステータスライン (lualine など)
+
+```lua
+-- lualine の設定に追加:
+sections = {
+  lualine_x = {
+    { require("copilot_hunk.decoration").statusline_component },
+  }
+}
+```
+
+現在のバッファに 3 つの pending AI hunk がある場合、`🤖 3` と表示されます。
+
+### nvim-tree / neo-tree
+
+プラグインは pending hunk のあるバッファに HINT レベルの diagnostic を設定します。
+nvim-tree と neo-tree は `vim.diagnostic.get()` を自動的に読み取り、
+pending hunk のあるファイルにロボットアイコン 🤖 を表示します — 追加設定は不要です。
+
+### Telescope / FZF
+
+そのまま動作します。Telescope や FZF で pending AI hunk のあるファイルを開くと、
+hunk が自動的に表示されます。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,35 @@ No manual setup needed: the review session starts and ends automatically.
 
 - **Auto-detection of AI edits** — no manual snapshot step.
   When an external tool writes a file, `FileChangedShell` / `FocusGained` fires and
-  a review session starts automatically.
+  a review session starts automatically. Unloaded buffers are also detected via
+  `git diff` / `git ls-files` on `FocusGained`.
 - **Formatter false-positive prevention** — `BufWritePre` timestamp guard ignores
   file changes within 2 seconds of a Neovim save (stylua, prettier, LSP format, etc.).
 - **Inline diff with 2-tier colouring** — muted background on the entire changed line,
   vivid overlay on the changed text region (like GitHub's diff view).
 - **Character-level diff** — within change hunks, the exact modified characters are
   highlighted with an even stronger colour (`CopilotHunkChangeChar`).
-- **Hunk counter** — each pending hunk shows `[1/3]` virtual text at end-of-line.
+- **Hunk counter** — each pending hunk shows `[1/4]` virtual text at end-of-line
+  (global across all files).
 - **`n` / `N` navigation with wrap-around** — jump between hunks just like search.
 - **Cross-file navigation** — `n` / `N` crosses buffer boundaries when multiple files
   have active sessions, cycling through all pending hunks.
+- **New file / deleted file support** — AI-created files show all content as "add" hunks
+  (accept = save, reject = delete). AI-deleted files show all content as "delete" hunks
+  (accept = delete, reject = restore).
 - **Accept / reject at three levels** — hunk (`ga` / `gr`), file (`gA` / `gR`),
-  or all files (`gAA` / `gRR`).
+  or all files (`gAA` / `gRR`). After accept/reject, the hunk highlight disappears
+  immediately and auto-jumps to the next pending hunk (even across files).
+- **Robot icon 🤖 decoration** — buffers with pending hunks get a HINT diagnostic,
+  automatically picked up by nvim-tree / neo-tree to show the 🤖 icon.
+  Also provides `statusline_component()` for lualine integration.
+- **Notification control** — `notify_level` option (default `WARN`) suppresses
+  routine INFO notifications for a quieter experience.
+- **Reviewed-state persistence** — after all hunks in a file are resolved, the file
+  path + SHA-256 hash is saved to `.git/copilot-hunk-reviewed`. On next session start,
+  matching files are skipped. Re-editing by AI auto-invalidates the hash.
+- **Telescope / FZF / nvim-tree compatibility** — when you open a file via Telescope
+  or FZF that has pending AI hunks, the session is auto-transferred to the new buffer.
 - **Git-independent** — works on any buffer, no Git repo required.
 
 ---
@@ -64,13 +80,19 @@ use {
 
 ```lua
 require("copilot_hunk").setup({
-  enable_auto_snapshot = true,   -- auto-detect AI file edits
-  signs   = false,               -- sign column markers (default: false)
-  keymaps = true,                -- install default keymaps
+  enable_auto_snapshot = true,     -- auto-detect AI file edits (default: true)
+  signs   = false,                 -- sign column markers (default: false)
+  keymaps = true,                  -- install default keymaps (default: true)
+  cross_file_navigation = true,    -- n/N crosses file boundaries (default: true)
+  notify_level = vim.log.levels.WARN,  -- notification verbosity (default: WARN)
+  decorations = {
+    winbar = false,                -- WinBar display (default: false)
+    icon   = "🤖",                -- icon for WinBar/statusline
+  },
   highlights = {
-    add    = {},   -- override CopilotHunkAdd bg
-    delete = {},   -- override CopilotHunkDelete bg
-    change = {},   -- override CopilotHunkChange bg
+    add    = {},                   -- override CopilotHunkAdd bg
+    delete = {},                   -- override CopilotHunkDelete bg
+    change = {},                   -- override CopilotHunkChange bg
   },
 })
 ```
@@ -119,6 +141,34 @@ end)
 | `:CopilotHunkAcceptAllFiles` | Accept all hunks across all active sessions |
 | `:CopilotHunkRejectAllFiles` | Reject all hunks across all active sessions |
 | `:CopilotHunkEnd` | End the current session |
+
+---
+
+## Integrations
+
+### Statusline (lualine, etc.)
+
+```lua
+-- In your lualine config:
+sections = {
+  lualine_x = {
+    { require("copilot_hunk.decoration").statusline_component },
+  }
+}
+```
+
+Shows `🤖 3` when the current buffer has 3 pending AI hunks.
+
+### nvim-tree / neo-tree
+
+The plugin places a HINT-level diagnostic on buffers with pending hunks.
+nvim-tree and neo-tree automatically read `vim.diagnostic.get()` and show
+the robot icon 🤖 on files with pending hunks — no extra configuration needed.
+
+### Telescope / FZF
+
+Works out of the box. When you open a file via Telescope or FZF that has
+pending AI hunks, the hunks are automatically displayed.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -42,16 +42,35 @@ FileChangedShell  ──→  if now() - last_nvim_write[buf] < 2000ms → skip (
                          else → snap_store[buf] = current lines
 ```
 
-### 3つの検出パス
+### 4つの検出パス
 
 | シナリオ | Neovim autoread | イベント系列 |
 |---|---|---|
 | Neovim 起動中に AI が編集 | 任意 | `FileChangedShell` → `FileChangedShellPost` |
 | ユーザー不在中に AI が編集 | true | `FocusGained` → (autoread reload) → `BufReadPost` |
 | Neovim フォーカス中・非アクティブバッファ変更 | 任意 | `BufEnter` → checktime → `FileChangedShell` → `FileChangedShellPost` |
+| 未ロードバッファ・新規/削除ファイル | 任意 | `FocusGained` → `_detect_ai_edited_via_git()` |
 
 - **FocusGained**: 全ロード済み通常バッファのスナップショットを取得後、`checktime` を実行
 - **BufEnter**: スナップショット + `checktime` + 2 秒クリーンアップタイマー（未変更スナップの破棄）
+
+### `_detect_ai_edited_via_git()`
+
+`FocusGained` 時に以下の git コマンドを実行し、Neovim で未ロードのファイルを検出する:
+
+- `git diff --name-only HEAD` → 変更済みファイル
+- `git ls-files --others --exclude-standard` → 新規ファイル
+- `git ls-files --deleted` → 削除ファイル
+
+検出されたファイルは非表示バッファとして読み込まれセッションが開始される。
+
+### BufEnter ハンドラの 3 ケース
+
+| ケース | 条件 | 処理 |
+|---|---|---|
+| Case 1 | セッション既存 (`_sessions[bufnr]` あり) | `_rerender_all()` で extmark 再描画 |
+| Case 2 | 同ファイル・異なる bufnr (Telescope/FZF 経由) | `_transfer_session()` でセッション転送 |
+| Case 3 | セッションなし | 通常のスナップショット + checktime |
 
 ## キーマップ (セッション中のみ有効)
 
@@ -88,6 +107,24 @@ FileChangedShell  ──→  if now() - last_nvim_write[buf] < 2000ms → skip (
 - これにより、1ファイルしか開いていなくても `[1/2]` のようにグローバルカウンターが正しく表示される
 - `n`/`N` で未ロードバッファへ移動すると、自動的に `buflisted = true` に設定される
 - git が利用できないプロジェクトでは静かにスキップされる
+
+## 新規ファイル / 削除ファイル対応
+
+AI が新規作成・削除したファイルにも対応する。
+
+### 新規ファイル (`_session_kind = "new_file"`)
+
+- AI が新規作成したファイルを `git ls-files --others --exclude-standard` で検出
+- 全行が「追加」hunk として表示される (`diff({}, lines)`)
+- **accept**: `:write!` でファイルを保存
+- **reject**: ファイルを削除 (`vim.fn.delete()`)
+
+### 削除ファイル (`_session_kind = "deleted_file"`)
+
+- AI が削除したファイルを `git ls-files --deleted` で検出
+- 全行が「削除」hunk として表示される (`diff(lines, {})`)
+- **accept**: バッファを削除 (ファイルは削除されたまま)
+- **reject**: `writefile()` でファイルを復元
 
 ## ビジュアル仕様
 
@@ -148,6 +185,10 @@ require('copilot_hunk').setup({
   -- false にすると現在バッファ内のみでラップする
   cross_file_navigation = true,
 
+  -- 通知レベル (default: vim.log.levels.WARN = INFOを抑制)
+  -- vim.log.levels.INFO にすると全通知を表示
+  notify_level = vim.log.levels.WARN,
+
   -- デコレーション設定
   decorations = {
     winbar = false,  -- WinBar 表示 (default: false)
@@ -162,6 +203,47 @@ require('copilot_hunk').setup({
   },
 })
 ```
+
+## レビュー済み永続化
+
+ファイル内の全 hunk が accept/reject で解決されると、レビュー済みとして永続保存される。
+
+- accept 完了時に `.git/copilot-hunk-reviewed` にファイルパス + SHA-256 ハッシュを書き込む
+- 次回 Neovim 起動時にハッシュ照合し、一致すればスキップ (セッションを開始しない)
+- AI が再編集するとファイル内容が変わりハッシュが不一致になるため、自動的に再検出される
+
+## デコレーション
+
+pending hunk のあるバッファには以下のデコレーションが適用される。
+
+### diagnostic API
+
+- `vim.diagnostic.set()` で namespace `copilot_hunk_diag` に HINT エントリを設定
+- `vim.diagnostic.config({ float = false, signs = false, underline = false, virtual_text = false }, _ns)` で表示を完全抑制 (プログラム的な読み取り専用)
+- nvim-tree / neo-tree はこの diagnostic を自動的に読み取りアイコンを表示する
+
+### バッファ変数
+
+- `vim.b[bufnr].copilot_hunk_active` — セッションがアクティブかどうか (`true` / `false`)
+- `vim.b[bufnr].copilot_hunk_count` — pending hunk の数
+
+### autocmd イベント
+
+- `User CopilotHunkSessionChanged` — データ: `{ bufnr, active, pending }`
+
+### statusline_component()
+
+```lua
+require("copilot_hunk.decoration").statusline_component()
+-- → "🤖 3" (pending hunk がある場合)
+-- → ""    (セッションなしの場合)
+```
+
+lualine 等のステータスラインプラグインで使用する。
+
+### WinBar
+
+`decorations.winbar = true` にすると、セッション中のバッファの WinBar にロボットアイコンが表示される。
 
 ## Non-goals (意図的に実装しないもの)
 


### PR DESCRIPTION
## 概要

全ドキュメントを v0.3.6 の実装状態に合わせて更新。

### 変更内容

- **README.md / README.ja.md**: 新機能(新規/削除ファイル対応、🤖デコレーション、notify_level、レビュー済み永続化、Telescope互換)を追加。設定例を全オプション対応に更新。Integrations セクションを新設。
- **SPEC.md**: 4つ目の検出パス(_detect_ai_edited_via_git)、BufEnterハンドラ3ケース、新規/削除ファイル対応、notify_level、レビュー済み永続化、デコレーション詳細セクションを追加。
- **CHANGELOG.md**: v0.1.0〜v0.3.6 の全バージョン履歴を記載。